### PR TITLE
Add a remark about the accepted values in the dt parameter

### DIFF
--- a/source/includes/Tracking/_clicks.md
+++ b/source/includes/Tracking/_clicks.md
@@ -64,5 +64,5 @@ clurl | Click URL | string | The URL of the clicked search result
 cli | Clicked search result index | string | The index of the clicked search result
 cloi | Clicked banner ID | string | The ID of the banner, if it was a banner that was clicked
 title | Title | string | The title of the clicked search result
-dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. We recommend sticking to these to be consistent with the script.
+dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualizational services. If not passed correctly all services relying on them won't work as expected.
 

--- a/source/includes/Tracking/_clicks.md
+++ b/source/includes/Tracking/_clicks.md
@@ -64,5 +64,5 @@ clurl | Click URL | string | The URL of the clicked search result
 cli | Clicked search result index | string | The index of the clicked search result
 cloi | Clicked banner ID | string | The ID of the banner, if it was a banner that was clicked
 title | Title | string | The title of the clicked search result
-dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualizational services. If not passed correctly all services relying on them won't work as expected.
+dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualization services. If not passed correctly all services relying on them won't work as expected.
 

--- a/source/includes/Tracking/_clicks.md
+++ b/source/includes/Tracking/_clicks.md
@@ -64,5 +64,4 @@ clurl | Click URL | string | The URL of the clicked search result
 cli | Clicked search result index | string | The index of the clicked search result
 cloi | Clicked banner ID | string | The ID of the banner, if it was a banner that was clicked
 title | Title | string | The title of the clicked search result
-dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualization services. If not passed correctly all services relying on them won't work as expected.
-
+dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualization services. If not passed correctly, all services relying on them won't work as expected.

--- a/source/includes/Tracking/_queries.md
+++ b/source/includes/Tracking/_queries.md
@@ -66,4 +66,4 @@ ql | Quicklink ID | string | The quicklink ID, if a quicklink redirection occurs
 qid | Query ID | string | A unique string used as the ID of the query
 sid | Visitor session ID | string | A unique string used as the ID of the visitor session
 qsid | Query session ID | string | A unique string used as the ID of the query session
-dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. We recommend sticking to these to be consistent with the script.
+dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualizational services. If not passed correctly all services relying on them won't work as expected.

--- a/source/includes/Tracking/_queries.md
+++ b/source/includes/Tracking/_queries.md
@@ -66,4 +66,4 @@ ql | Quicklink ID | string | The quicklink ID, if a quicklink redirection occurs
 qid | Query ID | string | A unique string used as the ID of the query
 sid | Visitor session ID | string | A unique string used as the ID of the visitor session
 qsid | Query session ID | string | A unique string used as the ID of the query session
-dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualizational services. If not passed correctly all services relying on them won't work as expected.
+dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualization services. If not passed correctly all services relying on them won't work as expected.

--- a/source/includes/Tracking/_queries.md
+++ b/source/includes/Tracking/_queries.md
@@ -66,4 +66,4 @@ ql | Quicklink ID | string | The quicklink ID, if a quicklink redirection occurs
 qid | Query ID | string | A unique string used as the ID of the query
 sid | Visitor session ID | string | A unique string used as the ID of the visitor session
 qsid | Query session ID | string | A unique string used as the ID of the query session
-dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualization services. If not passed correctly all services relying on them won't work as expected.
+dt | Device Type | string | The type of device from which the search has been performed. Currently, our cludo.js script supplies the abstract device types - mobile, tablet, or desktop. These accepted values are case sensitive and an important part of our visualization services. If not passed correctly, all services relying on them won't work as expected.


### PR DESCRIPTION
The goal is to point the API customers to the accepted values and to outline a warning about the consequences if they use their own without specifically stating that they can use their own.
As Josh said: At the end of the day, the customer should think they can only send one of those three values.